### PR TITLE
Update validation_confluence.py

### DIFF
--- a/validation_confluence.py
+++ b/validation_confluence.py
@@ -187,7 +187,7 @@ class ValidationConfluence:
              else:
                  #othewise closest mean
                  index=np.array(index[np.argmin(np.abs(np.array(glt)-model_q))])
-                 if np.size(index):
+                 if np.size(index)>1:
                      warnings.warn('identical mean q values')
                      index=index[0]
                  


### PR DESCRIPTION
Now generates single index if there is more than one, based on model meanq then overall length of timeseries. Also fixes a bug where non-usgs data had a 366 days added to time variable.