### PR TITLE
Uat2 updates consensus fix

### DIFF
--- a/validation_confluence.py
+++ b/validation_confluence.py
@@ -37,7 +37,7 @@ import seaborn as sb
 
 # Local imports
 from val.validation import stats
-from sos_read.sos_read import download_sos
+#from sos_read.sos_read import download_sos
 
 # Third-party imports
 from netCDF4 import Dataset, stringtochar,chartostring

--- a/validation_confluence.py
+++ b/validation_confluence.py
@@ -315,17 +315,19 @@ class ValidationConfluence:
             "hivdi":"reach/Q",
             "momma":"Q",
             "sad":"Qa",  
-            "sic4dvar":"Q_da",        
+            "sic4dvar":"Q_da",
+            "consensus":"consensus_q",        
             
             
         }
 
         flpe_file_metroman = f"{flpe_dir}/{'metroman'}/{self.reach_id}_metroman.nc"
         flpe_file_neobam = f"{flpe_dir}/{'geobam'}/{self.reach_id}_geobam.nc"
-        # flpe_file_hivdi = f"{flpe_dir}/{'hivdi'}/{self.reach_id}_h2ivdi.nc"
+        flpe_file_hivdi = f"{flpe_dir}/{'hivdi'}/{self.reach_id}_h2ivdi.nc"
         flpe_file_momma = f"{flpe_dir}/{'momma'}/{self.reach_id}_momma.nc"
         flpe_file_sad = f"{flpe_dir}/{'sad'}/{self.reach_id}_sad.nc"
         flpe_file_sic4dvar = f"{flpe_dir}/{'sic4dvar'}/{self.reach_id}_sic4dvar.nc"
+        flpe_file_consensus = f"{flpe_dir}/{'consensus'}/{self.reach_id}_consensus.nc"
         try:
             flpe_mm = Dataset(flpe_file_metroman, 'r')
         except:
@@ -350,6 +352,10 @@ class ValidationConfluence:
             flpe_si = Dataset(flpe_file_sic4dvar, 'r')
         except:
             flpe_si=-9999
+        try:
+            flpe_co = Dataset(flpe_file_consensus, 'r')
+        except:
+            flpe_co=-9999
       
         
         flpe_data = {}
@@ -392,18 +398,25 @@ class ValidationConfluence:
             conlen=len(flpe_data["sic4dvar"])
             flpe_si.close()
 
+        if flpe_co==-9999:
+            flpe_data["consensus"]=-9999
+        else:
+            flpe_data["consensus"] = flpe_si[convention_dict["consensus"]][:].filled(np.nan)
+            conlen=len(flpe_data["consensus"])
+            flpe_si.close()
+
         if conlen > 0:
-            #create pre-offline consensus
-            ALLQ=np.full((len(flpe_data.keys()),  conlen), np.nan)
-            for row in range(len(flpe_data.keys())):
-                ALGv=flpe_data[list(flpe_data.keys())[row]]
-                if np.size(ALGv)==conlen:
-                    ALGv[ALGv<0]=np.nan
-                    ALLQ[row,:]=ALGv
+            # #create pre-offline consensus
+            # ALLQ=np.full((len(flpe_data.keys()),  conlen), np.nan)
+            # for row in range(len(flpe_data.keys())):
+            #     ALGv=flpe_data[list(flpe_data.keys())[row]]
+            #     if np.size(ALGv)==conlen:
+            #         ALGv[ALGv<0]=np.nan
+            #         ALLQ[row,:]=ALGv
                 
 
-            consensus=np.nanmedian(ALLQ,axis=0)
-            flpe_data["consensus"]=consensus
+            # consensus=np.nanmedian(ALLQ,axis=0)
+            # flpe_data["consensus"]=consensus
             
             
             if self.is_flpe_valid(flpe_data):

--- a/validation_confluence.py
+++ b/validation_confluence.py
@@ -37,7 +37,7 @@ import seaborn as sb
 
 # Local imports
 from val.validation import stats
-#from sos_read.sos_read import download_sos
+from sos_read.sos_read import download_sos #this import does not work on a singularity container adn must be commented out to run offline
 
 # Third-party imports
 from netCDF4 import Dataset, stringtochar,chartostring
@@ -962,7 +962,8 @@ def run_validation():
     if sos_bucket:
         gage_dir = TMP_DIR
     else:
-        gage_dir = INPUT_DIR.joinpath("sos")
+        #gage_dir = INPUT_DIR.joinpath("sos")
+        gage_dir = INPUT.joinpath("sos")
 
     vc = ValidationConfluence(reach_data, FLPE, MOI, OFFLINE, INPUT, OUTPUT, run_type, gage_dir)
     vc.validate()


### PR DESCRIPTION
Issue with generating internal consensus rather than reading FLPE folder is now resolved. One variable for offline use also corrected. Note that for offline use the "from sos_read.sos_read import download_sos".

This import is for pulling the SOS from the S3 and not needed for offline runs, but will break things if left commented out.